### PR TITLE
bannerUrl in AddPostRequest 제거

### DIFF
--- a/src/main/java/com/themoment/officialgsm/domain/board/dto/request/AddPostRequest.java
+++ b/src/main/java/com/themoment/officialgsm/domain/board/dto/request/AddPostRequest.java
@@ -21,5 +21,5 @@ public class AddPostRequest {
 
     @NotNull
     private Category category;
-    private String bannerUrl;
+
 }


### PR DESCRIPTION
## 개요

- bannerUrl in AddPostRequest 제거

## 작업내용

- AddPostRequest class에 필요없는 필드인 bannerUrl이 존재하여 제거하였습니다.