### PR TITLE
timeFormat 수정

### DIFF
--- a/src/main/java/com/themoment/officialgsm/global/exception/ErrorResponse.java
+++ b/src/main/java/com/themoment/officialgsm/global/exception/ErrorResponse.java
@@ -1,6 +1,5 @@
 package com.themoment.officialgsm.global.exception;
 
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -15,7 +14,7 @@ import java.time.format.DateTimeFormatter;
 @Getter
 public class ErrorResponse {
 
-    private final String formatNow = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd / HH : mm : ss "));
+    private final String formatNow = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMddHHmmss"));
     private final String detailMessage;
 
     public static ResponseEntity<ErrorResponse> toResponseEntity(String detailMessage, HttpStatus httpStatus) {


### PR DESCRIPTION
## 개요

- timeFormat 수정

## 작업내용

- `ErrorResponse`클래스에서 반환하는 `formatNow`필드의 형식을 `yyyy-MM-dd / HH : mm : ss `에서 `yyyyMMddHHmmss`으로 변경하였습니다.