### PR TITLE
boardService 테스트코드 수정

### DIFF
--- a/src/test/java/com/themoment/officialgsm/service/board/BoardServiceTest.java
+++ b/src/test/java/com/themoment/officialgsm/service/board/BoardServiceTest.java
@@ -16,6 +16,7 @@ import com.themoment.officialgsm.global.util.UserUtil;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -49,6 +50,8 @@ class BoardServiceTest {
     private UserUtil userUtil;
     @Autowired
     private BoardService boardService;
+    @Autowired
+    private AwsS3Util awsS3Util;
 
     private AddPostRequest getAddPostRequest() {
         return AddPostRequest.builder()
@@ -95,6 +98,19 @@ class BoardServiceTest {
 
         // then
         assertNotNull(currentUser);
+    }
+
+    @AfterEach
+    void clearS3() {
+
+        List<File> fileList = fileRepository.findAll();
+        if (fileList.isEmpty()) {
+            return;
+        }
+
+        List<String> fileUrlList = fileList.stream().map(File::getFileUrl).toList();
+
+        awsS3Util.deleteS3(fileUrlList);
     }
 
     private void savePost(AddPostRequest addPostRequest, MockMultipartFile file) {


### PR DESCRIPTION
## 개요

- boardService 테스트코드 수정

## 작업내용

- 바뀐 User entity의 필드에 맞춰 builder를 수정하였습니다.
- 테스트가 끝날 때마다 s3에 업로드 했던 객체를 제거하는 작업을 추가하였습니다.