### PR TITLE
MASTER 권한 접근가능 URL 추가

### DIFF
--- a/src/main/java/com/themoment/officialgsm/global/security/SecurityConfig.java
+++ b/src/main/java/com/themoment/officialgsm/global/security/SecurityConfig.java
@@ -70,8 +70,8 @@ public class SecurityConfig {
                         .requestMatchers("/api/auth/userinfo").authenticated()
                         .requestMatchers("/api/auth/username").authenticated()
                         .requestMatchers("/api/post/**").hasAnyAuthority("ADMIN", "MASTER")
-                        .requestMatchers("/api/auth/unapproved/list").hasAuthority("ADMIN")
-                        .requestMatchers("/api/auth/approved/**").hasAuthority("ADMIN")
+                        .requestMatchers("/api/auth/unapproved/list").hasAnyAuthority("ADMIN", "MASTER")
+                        .requestMatchers("/api/auth/approved/**").hasAnyAuthority("ADMIN", "MASTER")
                         .anyRequest().permitAll();
         httpSecurity
                 .sessionManagement()


### PR DESCRIPTION
## 개요

- MASTER 권한 접근가능 URL 추가

## 작업내용

- `/api/auth/unapproved/list`와 `/api/auth/approved/**`에 `MASTER`권한을 가진 사람만 접근할 수 있도록 수정하였습니다.